### PR TITLE
fix proposal for #11

### DIFF
--- a/src/EventSourcing/EventSourcingRepository.php
+++ b/src/EventSourcing/EventSourcingRepository.php
@@ -89,6 +89,7 @@ class EventSourcingRepository implements EventSourcedRepository
                 array_merge(
                     $this->headerMapper->mapFromMessageHeaders($metadata),
                     [
+                        MessageHeaders::MESSAGE_ID => Uuid::uuid4()->toString(),
                         LazyProophEventStore::AGGREGATE_ID => $aggregateId,
                         LazyProophEventStore::AGGREGATE_TYPE => $aggregateClassName,
                         LazyProophEventStore::AGGREGATE_VERSION => $versionBeforeHandling + $eventNumber


### PR DESCRIPTION
without overwriting message id, all events will have the same ID if aggregate returns or records multiple events at once