### PR TITLE
add support for providing custom prooph persistence strategy

### DIFF
--- a/src/EventSourcing/EventSourcingConfiguration.php
+++ b/src/EventSourcing/EventSourcingConfiguration.php
@@ -6,6 +6,7 @@ namespace Ecotone\EventSourcing;
 
 use Enqueue\Dbal\DbalConnectionFactory;
 use Prooph\EventStore\InMemoryEventStore;
+use Prooph\EventStore\Pdo\PersistenceStrategy;
 use Prooph\EventStore\Projection\InMemoryProjectionManager;
 
 class EventSourcingConfiguration
@@ -19,6 +20,7 @@ class EventSourcingConfiguration
     private string $projectManagerReferenceName;
     private string $connectionReferenceName;
     private string $persistenceStrategy = LazyProophEventStore::SINGLE_STREAM_PERSISTENCE;
+    private ?PersistenceStrategy $customPersistenceStrategyInstance = null;
     private bool $isInMemory = false;
     private ?InMemoryEventStore $inMemoryEventStore = null;
     private ?\Prooph\EventStore\Projection\ProjectionManager $inMemoryProjectionManager = null;
@@ -63,6 +65,15 @@ class EventSourcingConfiguration
 
         return $this;
     }
+
+    public function withCustomPersistenceStrategy(PersistenceStrategy $persistenceStrategy): static
+    {
+        $this->persistenceStrategy = LazyProophEventStore::CUSTOM_STREAM_PERSISTENCE;
+        $this->customPersistenceStrategyInstance = $persistenceStrategy;
+
+        return $this;
+    }
+
 
     public function getInMemoryEventStore(): ?InMemoryEventStore
     {
@@ -127,6 +138,11 @@ class EventSourcingConfiguration
     public function getPersistenceStrategy(): string
     {
         return $this->persistenceStrategy;
+    }
+
+    public function getCustomPersistenceStrategy(): PersistenceStrategy
+    {
+        return $this->customPersistenceStrategyInstance;
     }
 
     public function getLoadBatchSize(): int

--- a/src/EventSourcing/LazyProophEventStore.php
+++ b/src/EventSourcing/LazyProophEventStore.php
@@ -44,6 +44,7 @@ class LazyProophEventStore implements EventStore
 
     const SINGLE_STREAM_PERSISTENCE = "single";
     const AGGREGATE_STREAM_PERSISTENCE = "aggregate";
+    const CUSTOM_STREAM_PERSISTENCE = "custom";
 
     const AGGREGATE_VERSION = '_aggregate_version';
     const AGGREGATE_TYPE = '_aggregate_type';
@@ -217,7 +218,8 @@ class LazyProophEventStore implements EventStore
     {
         return match ($this->eventSourcingConfiguration->getPersistenceStrategy()) {
             self::AGGREGATE_STREAM_PERSISTENCE => new PersistenceStrategy\MySqlAggregateStreamStrategy($this->messageConverter),
-            self::SINGLE_STREAM_PERSISTENCE => new PersistenceStrategy\MySqlSingleStreamStrategy($this->messageConverter)
+            self::SINGLE_STREAM_PERSISTENCE => new PersistenceStrategy\MySqlSingleStreamStrategy($this->messageConverter),
+            self::CUSTOM_STREAM_PERSISTENCE => $this->eventSourcingConfiguration->getCustomPersistenceStrategy(),
         };
     }
 
@@ -225,7 +227,8 @@ class LazyProophEventStore implements EventStore
     {
         return match ($this->eventSourcingConfiguration->getPersistenceStrategy()) {
             self::AGGREGATE_STREAM_PERSISTENCE => new PersistenceStrategy\MariaDbAggregateStreamStrategy($this->messageConverter),
-            self::SINGLE_STREAM_PERSISTENCE => new PersistenceStrategy\MariaDbSingleStreamStrategy($this->messageConverter)
+            self::SINGLE_STREAM_PERSISTENCE => new PersistenceStrategy\MariaDbSingleStreamStrategy($this->messageConverter),
+            self::CUSTOM_STREAM_PERSISTENCE => $this->eventSourcingConfiguration->getCustomPersistenceStrategy(),
         };
     }
 
@@ -233,7 +236,8 @@ class LazyProophEventStore implements EventStore
     {
         return match ($this->eventSourcingConfiguration->getPersistenceStrategy()) {
             self::AGGREGATE_STREAM_PERSISTENCE => new PersistenceStrategy\PostgresAggregateStreamStrategy($this->messageConverter),
-            self::SINGLE_STREAM_PERSISTENCE => new PersistenceStrategy\PostgresSingleStreamStrategy($this->messageConverter)
+            self::SINGLE_STREAM_PERSISTENCE => new PersistenceStrategy\PostgresSingleStreamStrategy($this->messageConverter),
+            self::CUSTOM_STREAM_PERSISTENCE => $this->eventSourcingConfiguration->getCustomPersistenceStrategy(),
         };
     }
 

--- a/tests/EventSourcing/Behat/Bootstrap/DomainContext.php
+++ b/tests/EventSourcing/Behat/Bootstrap/DomainContext.php
@@ -23,6 +23,7 @@ use Test\Ecotone\EventSourcing\Fixture\Basket\BasketEventConverter;
 use Test\Ecotone\EventSourcing\Fixture\Basket\Command\AddProduct;
 use Test\Ecotone\EventSourcing\Fixture\Basket\Command\CreateBasket;
 use Test\Ecotone\EventSourcing\Fixture\BasketListProjection\BasketList;
+use Test\Ecotone\EventSourcing\Fixture\CustomEventStream\CustomEventStreamProjection;
 use Test\Ecotone\EventSourcing\Fixture\ProjectionFromCategoryUsingAggregatePerStream\FromCategoryUsingAggregatePerStreamProjection;
 use Test\Ecotone\EventSourcing\Fixture\ProjectionFromMultipleStreams\MultipleStreamsProjection;
 use Test\Ecotone\EventSourcing\Fixture\SpecificEventStream\SpecificEventStreamProjection;
@@ -208,6 +209,11 @@ class DomainContext extends TestCase implements Context
                 case "Test\Ecotone\EventSourcing\Fixture\SpecificEventStream":
                 {
                     $objects = array_merge($objects, [new SpecificEventStreamProjection()]);
+                    break;
+                }
+                case "Test\Ecotone\EventSourcing\Fixture\CustomEventStream":
+                {
+                    $objects = array_merge($objects, [new CustomEventStreamProjection()]);
                     break;
                 }
                 case "Test\Ecotone\EventSourcing\Fixture\ProjectionFromCategoryUsingAggregatePerStream":

--- a/tests/EventSourcing/Behat/features/event-sourcing.feature
+++ b/tests/EventSourcing/Behat/features/event-sourcing.feature
@@ -189,6 +189,15 @@ Feature: activating as aggregate order entity
     And I create basket with id 1001
     Then the result of calling "action_collector.getCount" should be 1
 
+  Scenario: Verify handling custom event stream when custom stream persistence is enabled
+    Given I active messaging for namespaces
+      | Test\Ecotone\EventSourcing\Fixture\CustomEventStream                      |
+      | Test\Ecotone\EventSourcing\Fixture\Basket                      |
+      | Test\Ecotone\EventSourcing\Fixture\Ticket                      |
+    When I create basket with id 2000
+    And I create basket with id 2001
+    Then the result of calling "action_collector.getCount" should be 2
+
   Scenario: Verify handling specific event stream when aggregate bases stream persistence is enabled
     Given I active messaging for namespaces
       | Test\Ecotone\EventSourcing\Fixture\ProjectionFromCategoryUsingAggregatePerStream                      |

--- a/tests/EventSourcing/Fixture/CustomEventStream/CustomEventStreamProjection.php
+++ b/tests/EventSourcing/Fixture/CustomEventStream/CustomEventStreamProjection.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Test\Ecotone\EventSourcing\Fixture\CustomEventStream;
+
+use Ecotone\EventSourcing\Attribute\Projection;
+use Ecotone\Modelling\Attribute\EventHandler;
+use Ecotone\Modelling\Attribute\QueryHandler;
+use Test\Ecotone\EventSourcing\Fixture\Basket\Basket;
+use Test\Ecotone\EventSourcing\Fixture\Basket\Event\BasketWasCreated;
+
+#[Projection("custom_event_stream_projection", fromStreams: Basket::BASKET_STREAM)]
+class CustomEventStreamProjection
+{
+    private array $actions = [];
+
+    #[EventHandler(BasketWasCreated::EVENT_NAME)]
+    public function onBasketWasCreated(BasketWasCreated $event): void
+    {
+        $this->actions[] = $event;
+    }
+
+    #[QueryHandler("action_collector.getCount")]
+    public function countHappenedActions() : int
+    {
+        return count($this->actions);
+    }
+}

--- a/tests/EventSourcing/Fixture/CustomEventStream/EventSourcingConfiguration.php
+++ b/tests/EventSourcing/Fixture/CustomEventStream/EventSourcingConfiguration.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Test\Ecotone\EventSourcing\Fixture\CustomEventStream;
+
+use Ecotone\EventSourcing\FromProophMessageToArrayConverter;
+use Ecotone\Messaging\Attribute\ServiceContext;
+use Prooph\EventStore\Pdo\PersistenceStrategy\PostgresSingleStreamStrategy;
+
+class EventSourcingConfiguration
+{
+    #[ServiceContext]
+    public function aggregateStreamStrategy()
+    {
+        return \Ecotone\EventSourcing\EventSourcingConfiguration::createWithDefaults()
+            ->withCustomPersistenceStrategy(new PostgresSingleStreamStrategy(new FromProophMessageToArrayConverter()));
+    }
+}


### PR DESCRIPTION
Implementation for the ticket on the main ecotone repo:
https://github.com/ecotoneframework/ecotone/issues/14

Hopefully these changes are good enough, I'm not sure if the test coverage is as desired.
Wasn't able to test the changes locally with the automation tools, those result into the following error:

```
1) Test\Ecotone\EventSourcing\Integration\EventSourcingRepositoryBuilderTest::test_storing_and_retrieving
Error: Call to undefined method Ecotone\Enqueue\OutboundMessageConverter::unsetEnqueueMetadata()

/data/app/src/EventSourcing/EventSourcingRepository.php:84
/data/app/tests/EventSourcing/Integration/EventSourcingRepositoryBuilderTest.php:52
```